### PR TITLE
Update to allow optional remoteID

### DIFF
--- a/rest-api-v1.0.0.json
+++ b/rest-api-v1.0.0.json
@@ -3543,7 +3543,7 @@
               "remoteID": {
                   "type": "string",
                   "maxLength": 128,
-                  "description": "It is provided by the developer. Non-empty remoteID means that the feedback was given explicitly about the connection between these two parties."
+                  "description": "It is provided by the developer. Non-empty remoteID means that the feedback was given explicitly about the connection between these two parties. Otherwise it is regarded as general conference feedback."
               },
               "feedback": {
                   "type": "object",


### PR DESCRIPTION
Allow remoteID to be optional, it is only required if submitting feedback for a specific endpoint