### PR TITLE
Fix fabric setup required ICE fields

### DIFF
--- a/rest-api-v1.0.0.json
+++ b/rest-api-v1.0.0.json
@@ -3710,7 +3710,10 @@
               "timestamp",
               "eventType",
               "remoteID",
-              "connectionID"
+              "connectionID",
+              "localIceCandidates",
+              "remoteIceCandidates",
+              "iceCandidatePairs"
           ],
           "properties": {
               "localID": {


### PR DESCRIPTION
Karthik found a discrepancy between code and docs. I believe these should always be required as there is seems to never be a case where fabric is set up without these.