### PR TITLE
Remove required attribute from mediaAction events

### DIFF
--- a/rest-api-v1.0.0.json
+++ b/rest-api-v1.0.0.json
@@ -4090,10 +4090,7 @@
               "eventType",
               "localID",
               "deviceID",
-              "timestamp",
-              "mediaDeviceID",
-              "remoteIDList"
-
+              "timestamp"
           ],
           "properties": {
             "eventType": {


### PR DESCRIPTION
Remove required attribute from mediaAction events to reflect updated REST validations

https://app.clubhouse.io/callstatsio/story/7328/mediadeviceid-and-remoteidlist-must-be-optional-params-in-media-action-events